### PR TITLE
Allows underscore in module names, after the first character.

### DIFF
--- a/src/Elm/Module.elm
+++ b/src/Elm/Module.elm
@@ -70,7 +70,12 @@ isGoodChunk chunk =
       False
 
     Just (char, rest) ->
-      Char.isUpper char && String.all Char.isAlphaNum rest
+      Char.isUpper char && String.all isValidNameContinuation rest
+
+
+isValidNameContinuation : Char -> Bool
+isValidNameContinuation char =
+  Char.isAlphaNum char || char == '_'
 
 
 


### PR DESCRIPTION
This fix allows _ characters in module names as described here #12

I have tested it against the `elm.json` from 

https://package.elm-lang.org/packages/AdrianRibao/elm-derberos-date/1.0.1/elm.json